### PR TITLE
Establish testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.coverage
+.tox
+*.pyc
+PasteDeploy.egg-info
+coverage.xml
+htmlcov

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+sudo: false
+dist: xenial
+language: python
+install:
+      - pip install tox
+script:
+      - tox
+matrix:
+    include:
+        - python: 2.7
+          env: TOXENV=py27
+        - python: 3.4
+          env: TOXENV=py34
+        - python: 3.5
+          env: TOXENV=py35
+        - python: 3.6
+          env: TOXENV=py36
+        - python: 3.7
+          env: TOXENV=py37
+        - python: pypy
+          env: TOXENV=pypy
+          dist: trusty
+        - python: pypy3
+          env: TOXENV=pypy3
+          dist: trusty

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
-envlist = py26, py27, py33, py34, py35, pypy
+envlist = py27, py34, py35, py36, py37, pypy, pypy3
 
 [testenv]
+usedevelop = True
 deps =
     # Paste works on Python 3 since Paste 2.0
     Paste


### PR DESCRIPTION
Bring tox defaults into a reasonable state, removing env
aliases that tox no longer supports.

Set up travis.ci, including using dist: xenial to get python
3.7 support. pypy is only in trusty.

In the process add a .gitignore so ignored files don't get
in the way of doing this work.