### PR TITLE
Make 'python setup.py test' work

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,2 @@
 [pytest]
-addopts = --cov=paste/deploy --cov-report=xml --cov-report=html --cov-report=term-missing
 testpaths = tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [wheel]
 universal = true
+
+[aliases]
+test = pytest

--- a/setup.py
+++ b/setup.py
@@ -42,8 +42,8 @@ setup(
     packages=find_packages(exclude=['tests']),
     include_package_data=True,
     zip_safe=False,
-    test_suite='nose.collector',
-    tests_require=['nose>=0.11'],
+    setup_requires=['pytest-runner'],
+    tests_require=['pytest'],
     extras_require={
         'Config': [],
         'Paste': ['Paste'],

--- a/tests/test_config_middleware.py
+++ b/tests/test_config_middleware.py
@@ -20,7 +20,7 @@ def test_error():
     try:
         from paste.fixture import TestApp
     except ImportError:
-        raise SkipTest
+        raise pytest.skip('unable to import TestApp')
 
     wrapped = ConfigMiddleware(app_with_exception, {'test': 1})
     test_app = TestApp(wrapped)

--- a/tox.ini
+++ b/tox.ini
@@ -9,4 +9,4 @@ deps =
     pytest
     pytest-cov
 commands =
-    py.test {posargs}
+    py.test --cov=paste/deploy --cov-report=xml --cov-report=html --cov-report=term-missing {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,6 @@
 envlist = py27, py34, py35, py36, py37, pypy, pypy3
 
 [testenv]
-usedevelop = True
 deps =
     # Paste works on Python 3 since Paste 2.0
     Paste


### PR DESCRIPTION
Packagers sometimes like to use 'python setup.py test'. This
change adjusts setup.py and setup.cfg to allow this to work
with pytest instead of nose. To make things work, the
settings for coverage need to be moved into tox.ini.

A SkipTest in test_config_middleware is changed to its pytest
equivalent.