### PR TITLE
Prepare a 2.0.0 release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 PasteDeploy.egg-info
 coverage.xml
 htmlcov
+.eggs
+build
+dist

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -5,8 +5,8 @@ Paste Deployment News
 -----
 
 * Python 3 deprecation warning cleanups
-* Moved code to `GitHub <https://github.com/Pylons/pastedeploy>`_
-* Moved documentation of `Pylons Project <https://docs.pylonsproject.org/projects/pastedeploy/>`_
+* Moved code to `GitHub <https://github.com/Pylons/pastedeploy>`_ under the Pylons Project.
+* Moved documentation under the Pylons Project, hosted by Read the Docs at https://docs.pylonsproject.org/projects/pastedeploy/en/latest/
 
 1.5.2
 -----

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -1,6 +1,13 @@
 Paste Deployment News
 =====================
 
+2.0.0
+-----
+
+* Python 3 deprecation warning cleanups
+* Moved code to `GitHub <https://github.com/Pylons/pastedeploy>`_
+* Moved documentation of `Pylons Project <https://docs.pylonsproject.org/projects/pastedeploy/>`_
+
 1.5.2
 -----
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ docs_extras = [
 
 setup(
     name="PasteDeploy",
-    version="1.5.2",
+    version="2.0.0",
     description="Load, configure, and compose WSGI applications and servers",
     long_description=readme,
     classifiers=[


### PR DESCRIPTION
Update version in setup.py
Add changes to news.rst
Add build artifacts to .gitignore

The rationale for using a 2.0.0 version number is to make a
rather heavy-handed signal about the change in project
hosting and maintenance.