### PR TITLE
Remove pytest-runner integration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,2 @@
 [wheel]
 universal = true
-
-[aliases]
-test = pytest

--- a/setup.py
+++ b/setup.py
@@ -52,8 +52,6 @@ setup(
     packages=find_packages(exclude=["tests"]),
     include_package_data=True,
     zip_safe=False,
-    setup_requires=["pytest-runner"],
-    tests_require=["pytest"],
     extras_require={
         "Config": [],
         "Paste": ["Paste"],


### PR DESCRIPTION
`pytest-runner` describes itself as deprecated in its own package description, referring to https://github.com/pypa/setuptools/issues/1684.  Using it in `setup_requires` means that any other package that depends on PasteDeploy has to install `pytest-runner` too, which is fairly heavyweight and unnecessary.  (I ran into this when trying to update Launchpad to a less ancient version of PasteDeploy.)

This does mean that `python setup.py test` no longer works, but, according to the setuptools issue above, that's deprecated anyway.  PasteDeploy already has `tox` configuration that works well.

This is almost identical to https://github.com/cdent/paste/pull/47, and is for the same reasons.