### PR TITLE
Fix ConfigParser read_file compatibilty

### DIFF
--- a/paste/deploy/loadwsgi.py
+++ b/paste/deploy/loadwsgi.py
@@ -61,7 +61,10 @@ class NicerConfigParser(ConfigParser):
         if hasattr(self, '_interpolation'):
             self._interpolation = self.InterpolateWrapper(self._interpolation)
 
-    read_file = getattr(ConfigParser, 'read_file', ConfigParser.readfp)
+    try:
+        read_file = ConfigParser.read_file
+    except AttributeError:
+        read_file = ConfigParser.readfp
 
     def defaults(self):
         """Return the defaults, with their values interpolated (with the


### PR DESCRIPTION
The existing compatibility code didn't actually work, for example see https://bugzilla.redhat.com/show_bug.cgi?id=2019873 which was run against an early alpha of 3.11.

The removal was postponed from 3.11, and instead will be removed in 3.12.

https://github.com/python/cpython/pull/92503

You can simulate the removal by finding your Python 3's `configparser.py` and deleting `readfp`.
